### PR TITLE
improve readability of date in collections

### DIFF
--- a/client/src/Collection.jsx
+++ b/client/src/Collection.jsx
@@ -139,6 +139,11 @@ const Collection = () => {
   };
       
 
+  const handleDate = (incomingDate) => {
+    const fixedDate = incomingDate.replace("T", " at ").replace("Z", "");
+    return fixedDate;
+  }
+
   return (
     <Wrapper>
        
@@ -198,7 +203,7 @@ const Collection = () => {
       <MyListItem key={resource.public_id}>
         <InnerList>
           <p>
-            <BoldSpan>Date:</BoldSpan> {resource.created_at}
+            <BoldSpan>Date:</BoldSpan> {handleDate(resource.created_at)}
           </p>
           <p>
             <BoldSpan>Duration:</BoldSpan> {resource.bytes}

--- a/client/src/SheetMusic.jsx
+++ b/client/src/SheetMusic.jsx
@@ -152,6 +152,11 @@ const SheetMusic = () => {
     }
   };
 
+  const handleDate = (incomingDate) => {
+    const fixedDate = incomingDate.replace("T", " at ").replace("Z", "");
+    return fixedDate;
+  }
+
   return (
     <Wrapper>
       <Title>Sheet Music Collection for {selectedProject}</Title>
@@ -206,7 +211,7 @@ const SheetMusic = () => {
       <GalleryWrapper>
         {sortImageResources(imageResources).map((image, index) => (
           <GalleryItem key={image.public_id + index}>
-            <MainText>Date: {image.created_at}</MainText>
+            <MainText><BoldSpan>Date:</BoldSpan> {handleDate(image.created_at)}</MainText>
             <Thumbnail  src={image.secure_url} alt={image.public_id} onClick={() => openModal(image)} />          
             <TagManager
               resource={image}
@@ -230,6 +235,10 @@ const SheetMusic = () => {
     </Wrapper>
   )
 }
+
+const BoldSpan = styled.span`
+  font-weight: 700;
+`
 
 const GalleryWrapper = styled.div`
   padding-top: 10px;


### PR DESCRIPTION
Date and time of recordings / image uploads were coming in from Cloudinary with a "T" separating date & time, and a "Z" at the end. Removed these when displaying them for better readability.