### PR TITLE
cleaned up Collection view

### DIFF
--- a/client/src/Collection.jsx
+++ b/client/src/Collection.jsx
@@ -205,9 +205,7 @@ const Collection = () => {
           <p>
             <BoldSpan>Date:</BoldSpan> {handleDate(resource.created_at)}
           </p>
-          <p>
-            <BoldSpan>Duration:</BoldSpan> {resource.bytes}
-          </p>
+      
         </InnerList>
         <TagManager
           resource={resource}

--- a/client/src/components/TagManager.jsx
+++ b/client/src/components/TagManager.jsx
@@ -17,7 +17,7 @@ const TagManager = ({ resource, onUpdateTags, onDeleteTag }) => {
   
     return (
       <Wrapper>
-        <MainText><BoldSpan>Tags: </BoldSpan>(tap to edit) </MainText>
+        {/* <MainText><BoldSpan>Tags: </BoldSpan>(tap to edit) </MainText> */}
         <TagList>
           {resource.tags.map((tag, index) => (
             <Tag key={index} tag={tag} onDelete={() => onDeleteTag(tag, resource.public_id)} />


### PR DESCRIPTION
In the audio collection, removed the "Duration: xxxx" element as it is not needed (we see the length of the audio clips in the clips themselves). Also removed the "Tags:" header as it's pretty clear these are tags. Result: cleaner-looking individual clips.